### PR TITLE
Lower R floor from 4.5.0 to 4.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ License: MIT + file LICENSE
 URL: https://github.com/sonsoleslp/tna/, http://sonsoles.me/tna/
 BugReports: https://github.com/sonsoleslp/tna/issues/
 Depends:
-    R (>= 4.5.0)
+    R (>= 4.4.0)
 Imports:
     checkmate,
     cli,


### PR DESCRIPTION
One-line DESCRIPTION change.

- 3b25016 cited ggrepel, but ggrepel is not imported anywhere.
- No R 4.5-only features used; `utilities.R` polyfills `%||%`.
- Matrix (via igraph, cograph) requires R >= 4.4 → 4.4 is the tight floor.

R CMD check clean on R 4.5. CI matrix on 4.4 recommended before merge.

Unblocks jamovi 2.6 users (mohsaqr/JTNA1.2#2).